### PR TITLE
채팅방에서 변경된 프로필 이미지 적용, 유저 토큰 보내기

### DIFF
--- a/src/pages/ChatListPage.js
+++ b/src/pages/ChatListPage.js
@@ -43,8 +43,8 @@ function ChatListPage() {
   const [rcate1, setRcate1] = useRecoilState(selectedRegion01)
   const [rcate2, setRcate2] = useRecoilState(selectedRegion02)
 
-  // 채팅 리스트 받아오기
-  async function getChatRooms(page, size, rcate1, rcate2) {
+  // 지역 채팅 리스트 받아오기
+  async function getChatRooms({ page, size, rcate1, rcate2 }) {
     const token = await getUserToken()
 
     try {
@@ -65,17 +65,36 @@ function ChatListPage() {
       console.log(error)
     }
   }
+  // 내 채팅 리스트 받아오기
+  async function getMyChatRooms({ page, size }) {
+    const token = await getUserToken()
+
+    try {
+      const response = await axios.get(`${CHAT_API}/api/v1/chat/my-room-list`, {
+        params: {
+          page,
+          size,
+        },
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+        },
+      })
+      return response
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
   useEffect(() => {
     // 채팅방 리스트 가져오기
-    // const myChatList = getChatRooms(myListPage - 1, 10, "", "")
     async function getRegionList() {
-      const regionChatList = await getChatRooms(
-        regionListPage - 1,
-        10,
+      const regionChatList = await getChatRooms({
+        page: regionListPage - 1,
+        size: 10,
         rcate1,
         rcate2,
-      )
+      })
       const result = regionChatList.data.result
       console.log(result)
       setRecentRoomList(result.content)
@@ -85,27 +104,18 @@ function ChatListPage() {
       getRegionList()
     }
 
-    // 임시 데이터
-    setMyListMaxPage(5)
-    setRegionListMaxPage(10)
-
-    setMyRoomList([
-      {
-        id: "635a9c1df13f3d593f8346fc",
-        title: "채팅 테스트용 방",
-        isPrivate: true,
-        startDate: "2022-10-29",
-        endDate: "2022-11-11",
-        rcate1: "서울",
-        rcate2: "종로구",
-        curParticipants: 1,
-        maxParticipants: 2,
-        longitude: "126.58",
-        latitude: "37.34",
-      },
-    ])
-
-  }, [myListPage, regionListPage, rcate1, rcate2])
+    async function getMyList() {
+      const myChatList = await getMyChatRooms({
+        page: myListPage - 1,
+        size: 10,
+      })
+      const result = myChatList.data.result
+      console.log(result)
+      setMyRoomList(result.content)
+      setMyListMaxPage(result.totalPage)
+    }
+    getMyList()
+  }, [myListPage, regionListPage, rcate2])
 
   // 지도 표시 리스트
   useEffect(() => {

--- a/src/pages/ChatRoom.js
+++ b/src/pages/ChatRoom.js
@@ -9,6 +9,8 @@ import { currentUserName, currentUserProf } from "../recoil/userAuth"
 import ChatSendForm from "../components/Chat/ChatSendForm"
 import Container from "../components/Layout/Container"
 
+import { getUserToken } from "../utils/getUserToken"
+
 let stompClient
 let subscription
 
@@ -19,6 +21,7 @@ function ChatRoom() {
   const [userProf, setUserProf] = useRecoilState(currentUserProf)
   const textInputRef = useRef()
   const messageListRef = useRef()
+  const [token, setToken] = useState("")
 
   // 채팅방 구독
   const subscribe = () => {
@@ -79,52 +82,65 @@ function ChatRoom() {
   }
 
   useEffect(() => {
-    // stompClient 생성
-    stompClient = new StompJs.Client({
-      brokerURL: "ws://52.78.188.101:61613/stomp/chat",
-      connectHeaders: {
-        login: "user",
-        passcode: "password",
-      },
-      debug: function (str) {
-        console.log(str)
-      },
-      onConnect: () => {
-        // 연결 됐을 때 구독 시작
-        subscribe()
-      },
-      onStompError: function (frame) {
-        console.log("Broker reported error: " + frame.headers["message"])
-        console.log("Additional details: " + frame.body)
-      },
-      onDisconnect: () => {
-        disConnect()
-      },
-      reconnectDelay: 5000,
-      heartbeatIncoming: 4000,
-      heartbeatOutgoing: 4000,
-    })
-    stompClient.webSocketFactory = function () {
-      return new SockJS("http://52.78.188.101:8080/stomp/chat")
+    async function getToken() {
+      const newToken = await getUserToken()
+      setToken(newToken)
     }
+    getToken()
+  }, [])
 
-    stompClient.activate()
-    textInputRef.current.focus()
+  useEffect(() => {
+    // stompClient 생성
+    if (token !== "") {
+      stompClient = new StompJs.Client({
+        brokerURL: "ws://52.78.188.101:61613/stomp/chat",
+        connectHeaders: {
+          login: "user",
+          passcode: "password",
+          Authorization: token,
+        },
+        debug: function (str) {
+          console.log(str)
+        },
+        onConnect: () => {
+          // 연결 됐을 때 구독 시작
+          subscribe()
+        },
+        onStompError: function (frame) {
+          console.log("Broker reported error: " + frame.headers["message"])
+          console.log("Additional details: " + frame.body)
+        },
+        onDisconnect: () => {
+          disConnect()
+        },
+        reconnectDelay: 5000,
+        heartbeatIncoming: 4000,
+        heartbeatOutgoing: 4000,
+      })
+      stompClient.webSocketFactory = function () {
+        return new SockJS("http://52.78.188.101:8080/stomp/chat")
+      }
+
+      stompClient.activate()
+      textInputRef.current.focus()
+    }
 
     // 컴포넌트 언마운트 될 때 웹소켓 연결을 끊기
     return () => {
       disConnect()
     }
-  }, [])
+  }, [token])
 
   function disConnect() {
-    stompClient.deactivate()
-    subscription.unsubscribe()
-    console.log("연결 끊어짐")
+    if (stompClient) {
+      stompClient.deactivate()
+      subscription.unsubscribe()
+      console.log("연결 끊어짐")
+    }
   }
 
   // 메세지 전송
-  function handleSubmit(event) {
+  async function handleSubmit(event) {
     event.preventDefault()
     const input = event.target.querySelector("input")
     if (input.value === "") return
@@ -135,11 +151,16 @@ function ChatRoom() {
       senderImgSrc: userProf,
     }
 
+    const token = await getUserToken()
+
     stompClient.publish({
       destination: `/pub/chat.message.${roomId}`,
       body: JSON.stringify(message),
-      // headers: { priority: "9" },
+      headers: {
+        Authorization: token,
+      },
     })
+    console.log(message)
 
     input.value = ""
     textInputRef.current.focus()

--- a/src/pages/CreateChatPage.js
+++ b/src/pages/CreateChatPage.js
@@ -86,11 +86,7 @@ function CreateChatPage() {
   }
 
   function onChange(event) {
-    if (event.target.name === "privateRoom") {
-      const name = "privateRoom"
-      const value = event.target.value === "true" ? true : false
-      setInputValues({ ...inputValues, [name]: value, password: "" })
-    } else if (event.target.name === "maxParticipant") {
+    if (event.target.name === "maxParticipant") {
       const name = "maxParticipant"
       const value = parseInt(event.target.value)
       setInputValues({ ...inputValues, [name]: value })
@@ -151,32 +147,6 @@ function CreateChatPage() {
             onChange={onChange}
             required
           />
-          <br />
-          <span className={forLabel}>비밀 채팅방</span>
-          <input
-            type="radio"
-            id="isPrivateT"
-            name="privateRoom"
-            value="true"
-            className={forInput}
-            onChange={onChange}
-            disabled
-          />
-          <label htmlFor="isPrivateT" className="px-2">
-            비밀 채팅방
-          </label>
-          <input
-            type="radio"
-            id="isPrivateF"
-            name="privateRoom"
-            value="false"
-            className={forInput}
-            onChange={onChange}
-          />
-          <label htmlFor="isPrivateF" className="px-2">
-            공개 채팅방
-          </label>
-
           <br />
           <label htmlFor="startDate" className={forLabel}>
             여행 시작 날짜

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -163,13 +163,15 @@ function MyPage() {
                   right: 0,
                   bottom: 0,
                   backgroundColor: "rgba(15, 15, 15, 0.79)",
+                  zIndex: 30,
                 },
                 content: {
                   position: "absolute",
-                  top: "20%",
-                  left: "35%",
-                  width: "30%",
-                  height: "30%",
+                  top: "50%",
+                  left: "50%",
+                  transform: "translate(-50%, -50%)",
+                  width: "fit-content",
+                  height: "fit-content",
                   border: "1px solid #ccc",
                   background: "#fff",
                   overflow: "auto",
@@ -183,7 +185,7 @@ function MyPage() {
               <h3 className="text-lg text-blue-300 font-semibold mb-2">
                 개인정보 수정
               </h3>
-              <form className="w-full max-w-sm ml-32 mt-20">
+              <form className="w-full max-w-sm mt-20">
                 <div className="md:flex md:items-center mb-6 mt-10">
                   <div className="md:w-1/3">
                     <label

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -309,9 +309,9 @@ function MyPage() {
             /> */}
             <form className="login-form grid place-items-center my-4">
               <ul className="h-1/2">
-                {userFollower.map((follow) => {
-                  ;<li key={follow.userId}>{follow.nickname}</li>
-                })}
+                {userFollower.map((follow) => (
+                  <li key={follow.userId}>{follow.nickname}</li>
+                ))}
               </ul>
               <PaginationBox>
                 <Pagination
@@ -334,9 +334,9 @@ function MyPage() {
             /> */}
             <form className="login-form grid place-items-center my-4">
               <ul className="h-1/2">
-                {userFollowing.map((follow) => {
-                  ;<li key={follow.userId}>{follow.nickname}</li>
-                })}
+                {userFollowing.map((follow) => (
+                  <li key={follow.userId}>{follow.nickname}</li>
+                ))}
               </ul>
               <PaginationBox>
                 <Pagination

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -4,10 +4,12 @@ import styled from "styled-components"
 import Pagination from "react-js-pagination"
 import Modal from "react-modal"
 import axios from "axios"
+import { useRecoilState } from "recoil"
 
 import { DEFAULT_API } from "../apis"
 import { getUserToken } from "../utils/getUserToken"
 import { data } from "autoprefixer"
+import { currentUserName, currentUserProf } from "../recoil/userAuth"
 
 function MyPage() {
   const [userInfo, setInfo] = useState([])
@@ -30,6 +32,10 @@ function MyPage() {
   const modalOff = () => {
     setModal(false)
   }
+
+  // 유저 정보 수정하면 로컬스토리지에도 적용
+  const [userName, setUserName] = useRecoilState(currentUserName)
+  const [userProf, setUserProf] = useRecoilState(currentUserProf)
 
   useEffect(() => {
     const token = getUserToken().then((token) => {
@@ -72,7 +78,7 @@ function MyPage() {
         })
         .catch((err) => console.log(err))
     })
-  }, [])
+  }, [userName, userProf])
 
   // 개인정보 수정
   const edit = async () => {
@@ -83,29 +89,37 @@ function MyPage() {
       formData.append("multipartFiles", file)
     })
 
-    axios
-      .patch(`${DEFAULT_API}/api/v1/users/profileImage`, formData, {
-        headers: {
-          Authorization: token,
-          "Content-Type": "multipart/form-data",
-        },
-      })
-      .then((res) => {
-        console.log("Profile Image Changed successfully")
-      })
-      .catch((err) => console.log(err))
+    if (multipartFiles.length !== 0) {
+      axios
+        .patch(`${DEFAULT_API}/api/v1/users/profileImage`, formData, {
+          headers: {
+            Authorization: token,
+            "Content-Type": "multipart/form-data",
+          },
+        })
+        .then((res) => {
+          console.log("Profile Image Changed successfully")
+          setUserProf(res.data.result.profileImagePath)
+          setMultipartFiles([])
+        })
+        .catch((err) => console.log(err))
+    }
 
-    axios
-      .patch(`${DEFAULT_API}/api/v1/users/nickname`, nickname, {
-        headers: {
-          Authorization: token,
-          "Content-Type": "application/json",
-        },
-      })
-      .then((res) => {
-        console.log("Nickname Changed successfully")
-      })
-      .catch((err) => console.log(err))
+    if (nickname !== "") {
+      axios
+        .patch(`${DEFAULT_API}/api/v1/users/nickname`, nickname, {
+          headers: {
+            Authorization: token,
+            "Content-Type": "application/json",
+          },
+        })
+        .then((res) => {
+          console.log("Nickname Changed successfully")
+          setUserName(res.data.result.nickname)
+          setNickname("")
+        })
+        .catch((err) => console.log(err))
+    }
   }
 
   // 이미지 경로 삽입

--- a/src/utils/getUserToken.js
+++ b/src/utils/getUserToken.js
@@ -7,7 +7,7 @@ export const getUserToken = async () => {
   let token = localStorage.getItem("token")
   const decoded = jwt_decode(token.split("Bearer ")[1])
 
-  if (decoded.exp < parseInt(Date.now() / 1000)) {
+  if (decoded.exp + 5 * 60 < parseInt(Date.now() / 1000)) {
     try {
       const response = await axios.get(`${DEFAULT_API}/api/v1/auth/refresh`, {
         headers: {


### PR DESCRIPTION
<!-- PR template -->

## 작업 내용
- 리프레시 토큰 요청 만료 5분전으로 수정
- 채팅리스트 페이지에 내 채팅 리스트 구현
- 비밀방 관련 삭제
- 채팅방에서 유저 토큰 보내기
- 마이페이지 개인정보(닉네임, 프로필 사진) 수정하면 로컬스토리지에도 반영 (채팅방에서는 로컬스토리지에서 닉네임, 프로필 사진 가져오기 때문에)
- 개인정보 수정 모달 창 사이즈, z-index 수정

## 기타 사항
- 마이페이지 팔로잉 팔로워 목록 map으로 나타낼 때 에디터에서 오류 나는 부분도 수정
- 개인정보 수정 모달 창에서 이미지나 닉네임 둘 중 하나만 수정할 때도 오류나지 않도록 edit 함수 내에 if 조건을 추가
- 개인정보 수정하면 마이페이지 새로고침 안해도 반영될 수 있게 수정